### PR TITLE
Potential fix for code scanning alert no. 27: Code injection

### DIFF
--- a/routes/trackOrder.ts
+++ b/routes/trackOrder.ts
@@ -15,7 +15,7 @@ export function trackOrder () {
     const id = !utils.isChallengeEnabled(challenges.reflectedXssChallenge) ? String(req.params.id).replace(/[^\w-]+/g, '') : utils.trunc(req.params.id, 60)
 
     challengeUtils.solveIf(challenges.reflectedXssChallenge, () => { return utils.contains(id, '<iframe src="javascript:alert(`xss`)">') })
-    db.ordersCollection.find({ $where: `this.orderId === '${id}'` }).then((order: any) => {
+    db.ordersCollection.find({ orderId: id }).then((order: any) => {
       const result = utils.queryResultToJson(order)
       challengeUtils.solveIf(challenges.noSqlOrdersChallenge, () => { return result.data.length > 1 })
       if (result.data[0] === undefined) {


### PR DESCRIPTION
Potential fix for [https://github.com/andersonvieira976/juice-shop-dsa/security/code-scanning/27](https://github.com/andersonvieira976/juice-shop-dsa/security/code-scanning/27)

To fix this code injection vulnerability, we should avoid using the `$where` operator with user input entirely. Instead, we should use a standard query object to search for the order by its `orderId` field. This approach is both safer and more efficient, as it does not require evaluating JavaScript on the database server. Specifically, replace the `$where` query with a direct query: `{ orderId: id }`. This change should be made on line 18 of `routes/trackOrder.ts`. No additional imports or methods are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
